### PR TITLE
Add summary for WF-FND-002 and normalize interference token color

### DIFF
--- a/GPT_5_DOCUMENTS/docs/WF-FND-002/summary.md
+++ b/GPT_5_DOCUMENTS/docs/WF-FND-002/summary.md
@@ -1,0 +1,8 @@
+# WF-FND-002: Summary
+
+- Defines the "output physics" mapping AI behavior to WIRTHFORGE's energy-based visualization metrics
+- Introduces measurable cues—time-to-first-token, emission speed, token probability—tied to lightning, streams, and interference metaphors
+- Charts five progressive visualization levels from single-model strikes to multi-model resonance fields
+- Describes a broker architecture for local-first execution with optional satellite models
+- Establishes strict 60 Hz performance targets to keep all visual effects scientifically truthful and traceable
+

--- a/GPT_5_DOCUMENTS/ui/WF-FND-002-design-tokens.json
+++ b/GPT_5_DOCUMENTS/ui/WF-FND-002-design-tokens.json
@@ -19,6 +19,7 @@
       "description": "Blue spectrum for continuous token flow visualization"
     },
     "interference": {
+      "primary": "#c084fc",
       "constructive": "#c084fc",
       "constructiveGlow": "#ddd6fe",
       "destructive": "#ef4444",


### PR DESCRIPTION
## Summary
- add standalone executive summary for WF-FND-002
- include primary color in interference palette to satisfy validation
- refine summary into bullet list for clarity

## Testing
- `node GPT_5_DOCUMENTS/tests/WF-FND-002/visual-asset-validation.js`


------
https://chatgpt.com/codex/tasks/task_e_689db2174eb4833381a59437effdb457